### PR TITLE
Add Storage.Devices to support ESP32 mount operations

### DIFF
--- a/source/Windows.Storage/FileIO.cs
+++ b/source/Windows.Storage/FileIO.cs
@@ -158,7 +158,7 @@ namespace Windows.Storage
         [System.Diagnostics.DebuggerStepThrough]
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public extern static void ReadTextNative(IStorageFile file, ref string text);
+        private extern static void ReadTextNative(IStorageFile file, ref string text);
         #endregion
 
     }

--- a/source/Windows.Storage/IStorageProvider.cs
+++ b/source/Windows.Storage/IStorageProvider.cs
@@ -7,6 +7,9 @@ using System;
 
 namespace Windows.Storage
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public interface IStorageProvider
     {
     }

--- a/source/Windows.Storage/KnownFolderId.cs
+++ b/source/Windows.Storage/KnownFolderId.cs
@@ -75,5 +75,11 @@ namespace Windows.Storage
         ///// Videos library folder.
         ///// </summary>
         //VideosLibrary = 13
+
+        /// <summary>
+        /// Internal devices.
+        /// </summary>
+        InternalDevices = 14
+
     }
 }

--- a/source/Windows.Storage/KnownFolders.cs
+++ b/source/Windows.Storage/KnownFolders.cs
@@ -28,6 +28,13 @@ namespace Windows.Storage
         /// </summary>
         public static StorageFolder RemovableDevices => new StorageFolder(KnownFolderId.RemovableDevices);
 
+
+        /// <summary>
+        /// Gets the internal devices folder.
+        /// </summary>
+        public static StorageFolder InternalDevices => new StorageFolder(KnownFolderId.InternalDevices);
+
+
         //public static StorageFolder SavedPictures { get; }
         //public static StorageFolder VideosLibrary { get; }
 

--- a/source/Windows.Storage/StorageDevices.cs
+++ b/source/Windows.Storage/StorageDevices.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+
+namespace Windows.Storage.Devices
+{
+    /// <summary>
+    /// Class to allow a single SDCard to be mounted on the system.
+    /// Only allows for 1 device to be mounted, either via MMC or SPI
+    /// </summary>
+    public static class SDCard
+    {
+
+#pragma warning disable 0649
+
+        // this field is set in native code
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        private static bool _mounted = false;
+
+#pragma warning restore 0649
+
+        /// <summary>
+        /// Indcates if the SDscard has been mounted
+        /// </summary>
+        public static bool IsMounted => _mounted;
+
+        /// <summary>
+        /// Mount the SDcard device on the MMC interface 
+        /// </summary>
+        /// <param name="Data1bit">If true denotes 1 bit data path will be used otherwise it will be 4 bits.</param>
+        /// <remarks>
+        /// This will try to mount the SDCard on the specified interface.
+        /// If the Card is not present or the card is unable to be read then an exception will be thrown.
+        /// </remarks>
+        [System.Diagnostics.DebuggerStepThrough]
+        public static void MountMMC(bool Data1bit)
+        {
+            MountMMCNative(Data1bit);
+            _mounted = true;
+        }
+
+        /// <summary>
+        /// Mount the SPI SDcard device on the specified SPI bus 
+        /// </summary>
+        /// <param name="SpiController">The name for the SPI device, i.e "SPI1" </param>
+        /// <param name="ChipSelect">The GPIO pin used for chip select on SDcard.</param>
+        /// <remarks>
+        /// This will try to mount the SDCard on the specified interface.
+        /// If the Card is not present or the card is unable to be read then an exception will be thrown.
+        /// </remarks>
+        [System.Diagnostics.DebuggerStepThrough]
+        public static void MountSpi(string SpiController, int ChipSelect)
+        {
+            // the SpiDevice is an ASCII string with the format 'SPIn'
+            // need to grab 'n' from the string and convert that to the integer value from the ASCII code (do this by subtracting 48 from the char value)
+            int spiBus = SpiController[3] - '0';
+            MountSpiNative(spiBus, ChipSelect);
+
+            // If no exception then set mounted flag
+            _mounted = true;
+        }
+
+        /// <summary>
+        /// Unmount the mounted SDcard.
+        /// </summary>
+        [System.Diagnostics.DebuggerStepThrough]
+        public static void Unmount()
+        {
+            UnmountNative();
+ 
+            // If no exception then set mounted flag
+            _mounted = false;
+        }
+
+#region Native Calls
+
+        [System.Diagnostics.DebuggerStepThrough]
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern static void MountMMCNative(bool Data1bit);
+
+        [System.Diagnostics.DebuggerStepThrough]
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void MountSpiNative(int SpiBus, int ChipSelect);
+
+        [System.Diagnostics.DebuggerStepThrough]
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void UnmountNative();
+
+#endregion
+
+    }
+}
+

--- a/source/Windows.Storage/StorageFile.cs
+++ b/source/Windows.Storage/StorageFile.cs
@@ -165,6 +165,11 @@ namespace Windows.Storage
         /// </summary>
         /// <param name="path">The path of the file to get a StorageFile to represent.</param>
         /// <returns>Returns the file as a StorageFile.</returns>
+        ///<remarks>
+        ///
+        /// This method is exclusive of nanoFramework and it's not available in the UWP API.
+        /// The equivalent method would be GetFileFromPathAsync(String).
+        ///</remarks>
         public static StorageFile GetFileFromPath(String path)
         {
             StorageFile file = new StorageFile();

--- a/source/Windows.Storage/StorageFile.cs
+++ b/source/Windows.Storage/StorageFile.cs
@@ -3,8 +3,8 @@
 // See LICENSE file in the project root for full license information.
 //
 
-
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Windows.Storage
 {
@@ -160,6 +160,22 @@ namespace Windows.Storage
         //        public static IAsyncOperation<StorageFile> GetFileFromPathAsync(String path)
         //        { }
 
+        /// <summary>
+        /// Gets a StorageFile object to represent the file at the specified path.
+        /// </summary>
+        /// <param name="path">The path of the file to get a StorageFile to represent.</param>
+        /// <returns>Returns the file as a StorageFile.</returns>
+        public static StorageFile GetFileFromPath(String path)
+        {
+            StorageFile file = new StorageFile();
+
+            CheckFileNative(path);
+
+            file._path = path;
+
+            return file;
+        }
+
         //        public IAsyncOperation<StorageFolder> GetParentAsync()
         //        { }
 
@@ -202,6 +218,7 @@ namespace Windows.Storage
         //        public IAsyncOperation<IRandomAccessStream> OpenAsync(FileAccessMode accessMode)
         //        { }
 
+
         //        public IAsyncOperation<IRandomAccessStream> OpenAsync(FileAccessMode accessMode, StorageOpenOptions options)
         //        { }
 
@@ -228,5 +245,12 @@ namespace Windows.Storage
 
         //        public static IAsyncOperation<StorageFile> ReplaceWithStreamedFileFromUriAsync(IStorageFile fileToReplace, Uri uri, IRandomAccessStreamReference thumbnail)
         //        { }
+
+
+        [System.Diagnostics.DebuggerStepThrough]
+        [System.Diagnostics.DebuggerHidden]
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void CheckFileNative(string filePath);
+
     }
 }

--- a/source/Windows.Storage/StorageFolder.cs
+++ b/source/Windows.Storage/StorageFolder.cs
@@ -18,6 +18,7 @@ namespace Windows.Storage
 
         private const string s_RemovableStorageDevicesName = "Removable Storage Devices";
         private const string s_RemovableStorageDevicesDisplayType = "System Folder";
+        private const string s_InternalStorageDevicesName = "Internal Storage Devices";
 
         #endregion
 
@@ -105,14 +106,22 @@ namespace Windows.Storage
 
         internal StorageFolder(KnownFolderId folderId)
         {
-            // currently there is only support for removable devices
-            if (folderId != KnownFolderId.RemovableDevices)
+            // currently there is only support for removable devices 
+            // and internal storage devices
+            if (folderId == KnownFolderId.RemovableDevices)
+            {
+                _name = s_RemovableStorageDevicesName;
+            }
+            else if (folderId == KnownFolderId.InternalDevices)
+            {
+                _name = s_InternalStorageDevicesName;
+            }
+            else
             {
                 throw new NotSupportedException();
             }
 
             _knownFolderId = folderId;
-            _name = s_RemovableStorageDevicesName;
             _path = "";
         }
 
@@ -310,13 +319,17 @@ namespace Windows.Storage
         public StorageFolder[] GetFolders()
         {
             // is this a call for a known folder ID
-            // RemovableDevices
+            // RemovableDevices & InternalDevices
             // nothing else is implemented, no need to check as this doesn't get pass the constructor StorageFolder(KnownFolderId folderId)
             if (_knownFolderId == KnownFolderId.RemovableDevices)
             {
                 return GetRemovableStorageFoldersNative();
             }
-
+            else if (_knownFolderId == KnownFolderId.InternalDevices)
+            {
+                return GetInternalStorageFoldersNative();
+            }
+ 
             // regular get folders
             return GetStorageFoldersNative();
         }
@@ -400,6 +413,11 @@ namespace Windows.Storage
         [System.Diagnostics.DebuggerHidden]
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern StorageFolder[] GetRemovableStorageFoldersNative();
+
+        [System.Diagnostics.DebuggerStepThrough]
+        [System.Diagnostics.DebuggerHidden]
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern StorageFolder[] GetInternalStorageFoldersNative();
 
         [System.Diagnostics.DebuggerStepThrough]
         [System.Diagnostics.DebuggerHidden]

--- a/source/Windows.Storage/Windows.Storage.nfproj
+++ b/source/Windows.Storage/Windows.Storage.nfproj
@@ -91,6 +91,7 @@
     <Compile Include="SetVersionDeferral.cs" />
     <Compile Include="SetVersionRequest.cs" />
     <Compile Include="StorageDeleteOption.cs" />
+    <Compile Include="StorageDevices.cs" />
     <Compile Include="StorageFile.cs" />
     <Compile Include="StorageFolder.cs" />
     <Compile Include="StorageItemTypes.cs" />


### PR DESCRIPTION
## Description
Added a Storage.Devices class to allow the mounting of SDCard devices from managed code
For MMC and SPI attached devices. Needed to supply SPI information and MMC data bit 4 or 1

Added a StorageFile GetFileFromPath(String path) method to allow the easy defining of an existing file to be opened.

Added a way to enumerate Internal flash drives for ESP32 or other devices

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
Tested each method is working for ESP32 internal drive and SDcard attached via MMC or SPI
Internal drive uses SPIFFS so there are no folders, the folder functions return "not supported"
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>