### PR TITLE
Bumps nanoFramework.Runtime.Events from 1.0.5-preview-019 to 1.0.6-preview-001

### DIFF
--- a/source/Windows.Storage/Windows.Storage.nfproj
+++ b/source/Windows.Storage/Windows.Storage.nfproj
@@ -52,7 +52,7 @@
     <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.Windows.Storage.Streams.1.0.5-preview-016\lib\Windows.Storage.Streams.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
-    <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.Runtime.Events.1.0.5-preview-019\lib\nanoFramework.Runtime.Events.dll">
+    <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.Runtime.Events.1.0.6-preview-001\lib\nanoFramework.Runtime.Events.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -131,8 +131,8 @@
       <HintPath>..\packages\nanoFramework.CoreLibrary.1.2.1-preview-001\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Events.1.0.5-preview-019\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.0.6-preview-001\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Windows.Storage.Streams, Version=1.0.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/source/Windows.Storage/packages.config
+++ b/source/Windows.Storage/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.2.1-preview-001" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.0.5-preview-019" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.0.6-preview-001" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Windows.Storage.Streams" version="1.0.5-preview-016" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.0.6-beta" developmentDependency="true" targetFramework="netnanoframework10" />
 </packages>

--- a/source/nanoFramework.Windows.Storage.DELIVERABLES.nuspec
+++ b/source/nanoFramework.Windows.Storage.DELIVERABLES.nuspec
@@ -20,7 +20,7 @@
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="[1.2.1-preview-001]" />
       <dependency id="nanoFramework.Windows.Storage.Streams" version="[1.0.5-preview-016]" />
-      <dependency id="nanoFramework.Runtime.Events" version="[1.0.5-preview-019]" />
+      <dependency id="nanoFramework.Runtime.Events" version="[1.0.6-preview-001]" />
     </dependencies>
   </metadata>
   <files>

--- a/source/nanoFramework.Windows.Storage.nuspec
+++ b/source/nanoFramework.Windows.Storage.nuspec
@@ -19,7 +19,7 @@
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="[1.2.1-preview-001]" />
       <dependency id="nanoFramework.Windows.Storage.Streams" version="[1.0.5-preview-016]" />
-      <dependency id="nanoFramework.Runtime.Events" version="[1.0.5-preview-019]" />
+      <dependency id="nanoFramework.Runtime.Events" version="[1.0.6-preview-001]" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Bumps nanoFramework.Runtime.Events from 1.0.5-preview-019 to 1.0.6-preview-001

[version update]
