### PR TITLE
Fix StorageFile.GetFileFromPath

### DIFF
--- a/source/Windows.Storage/Properties/AssemblyInfo.cs
+++ b/source/Windows.Storage/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("1.0.0.0")]
+[assembly: AssemblyNativeVersion("1.0.0.1")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/source/Windows.Storage/StorageFile.cs
+++ b/source/Windows.Storage/StorageFile.cs
@@ -160,8 +160,8 @@ namespace Windows.Storage
         public void Delete()
         {
             DeleteFileNative();
-        }        
-        
+        }
+
         //        public IAsyncAction DeleteAsync(StorageDeleteOption option)
         //        { }
 
@@ -186,20 +186,11 @@ namespace Windows.Storage
         ///</remarks>
         public static StorageFile GetFileFromPath(String path)
         {
-            StorageFile file = new StorageFile();
+            // get file name from path
+            int nameStartIndex = path.LastIndexOf("\\");
+            string fileName = path.Substring(nameStartIndex + 1);
 
-            CheckFileNative(path);
-
-            // Find last separator before name
-            int li = path.LastIndexOf('\\');
-            if (li >= 0 && (li + 1) < path.Length)
-            {
-                file._name = path.Substring(li + 1);
-            }
-
-            file._path = path;
-
-            return file;
+            return GetFileFromPathNative(path, fileName);
         }
 
         //        public IAsyncOperation<StorageFolder> GetParentAsync()
@@ -294,11 +285,10 @@ namespace Windows.Storage
         //        public static IAsyncOperation<StorageFile> ReplaceWithStreamedFileFromUriAsync(IStorageFile fileToReplace, Uri uri, IRandomAccessStreamReference thumbnail)
         //        { }
 
-
         [System.Diagnostics.DebuggerStepThrough]
         [System.Diagnostics.DebuggerHidden]
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern void CheckFileNative(string filePath);
+        private extern static StorageFile GetFileFromPathNative(String path, String name);
 
         [System.Diagnostics.DebuggerStepThrough]
         [System.Diagnostics.DebuggerHidden]


### PR DESCRIPTION
## Description
- Rework GetFileFromPath and native.
- Update AssemblyNativeVersion to 1.0.0.1.

## Motivation and Context
- The previous implementation wasn't filling in all the StorageFile properties.

## How Has This Been Tested?<!-- (if applicable) -->
- Sample app from samples repo. Specifically Scenario9_RenameFile.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
