### PR TITLE
Fix drive index detection

### DIFF
--- a/source/Windows.Storage/StorageEventManager.cs
+++ b/source/Windows.Storage/StorageEventManager.cs
@@ -48,7 +48,7 @@ namespace Windows.Storage
                 StorageEvent storageEvent = new StorageEvent
                 {
                     EventType = (StorageEventType)((data1 >> 16) & 0xFF),
-                    DriveIndex = (byte)(data1 & 0xFF),
+                    DriveIndex = (byte)(data2 & 0xFF),
                     Time = time
                 };
 

--- a/source/Windows.Storage/StorageEventManager.cs
+++ b/source/Windows.Storage/StorageEventManager.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) 2019 The nanoFramework project contributors
 // See LICENSE file in the project root for full license information.
 //


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The path argument of the removable device event should contain the path to the removable device which triggered the event. Because of a typo, this was always D: no matter if it was the SD card or the USB MSD causing the event.

## Motivation and Context
To solve this problem, the argument of the Event which is passed to the driveIndex variable, had to be changed from data1 to data2. The data1 argument contains the event type, category and subcategory. The subcategory is 0 and assigned to the last 8 Bytes, hence the driveIndex was always 0.

## How Has This Been Tested?<!-- (if applicable) -->
This has been tested on a custom STM32F427 based MCU board with SD card slot and USB host port.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: Martin Kuhn martin.kuhn@csa.ch